### PR TITLE
Change Boston to New England

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ The following U.S. East Coast and Central meetups are currently participating in
 
 - [Atlanta, GA](https://www.meetup.com/Write-the-Docs-Atlanta/)
 - [Austin, TX](https://www.meetup.com/WriteTheDocs-ATX-Meetup/)
-- [Boston, MA](http://www.meetup.com/Write-the-Docs-BOS/)
 - [Detroit, MI/Windsor, CAN](https://www.meetup.com/write-the-docs-detroit-windsor/)
 - [Florida](https://www.meetup.com/write-the-docs-florida/)
+- [New England](https://www.meetup.com/ne-write-the-docs/)
 - [Ottawa/Montreal, CAN](http://www.meetup.com/Write-The-Docs-YOW-Ottawa/)
 - [Philadelphia, PA](https://www.writethedocs.org/meetups/philly/)
 

--- a/zoom-coordinator-guide.md
+++ b/zoom-coordinator-guide.md
@@ -70,9 +70,9 @@ The Quorum program brings together various local Write the Docs meetup chapters 
 
 Atlanta, GA - https://www.meetup.com/Write-the-Docs-Atlanta/
 Austin, TX - https://www.meetup.com/WriteTheDocs-ATX-Meetup/
-Boston, MA - http://www.meetup.com/Write-the-Docs-BOS/
 Detroit, MI/Windsor, CAN (our host meetup!) - https://www.meetup.com/write-the-docs-detroit-windsor/
 Florida - https://www.meetup.com/write-the-docs-florida/
+New England - https://www.meetup.com/ne-write-the-docs/
 Ottawa/Montreal, CAN - http://www.meetup.com/Write-The-Docs-YOW-Ottawa/
 Philadelphia, PA - https://www.writethedocs.org/meetups/philly/
 ```


### PR DESCRIPTION
The Boston meetup recently changed their name to the New England meetup and changed their link. This PR updates the meetup name in two docs where it shows up.