### PR TITLE
Add April 2022 event details

### DIFF
--- a/past-quorum-meetups.md
+++ b/past-quorum-meetups.md
@@ -9,6 +9,18 @@ Listed by most recent to oldest:
     <th>Details</th>
   </tr>
   <tr>
+    <td>Date</td>
+    <td>ECQ</td>
+    <td>
+      <ul>
+        <li>Creating Documentation Developers Will Love (and Use!)</li>
+        <li>Sean Keegan</li>
+        <li>Sponsored by Florida WTD</li>
+        <li>56 participants, 175 RSVPs</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
     <td>3-24-2022</td>
     <td>WCQ</td>
     <td>


### PR DESCRIPTION
This PR updates the past Quorum events with the details for the April event.